### PR TITLE
更新v1.3.18，新增 gpt-5.6-sol、gpt-5.6-terra、gpt-5.6-luna 模型，优化版本号读取逻辑，修复版本…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,82 @@
 
 --
 
+## v1.3.21
+
+### 新增
+
+### 优化
+- Codex 版本号读取新增 `~/.codex/models_cache.json` 的 `client_version` 作为优先回退来源，并在 `version.json`、`models_cache.json`、`codex --version` 之间取可用的较新版本号，减少新模型被误判为版本过旧的情况。#21
+
+### 修复
+- 修复部分环境下虽然 Codex CLI 已升级，但本地应用仍可能回退到旧版本号发起请求，导致 `gpt-5.6-sol` 等模型继续报需要升级 Codex 的问题。
+
+### Added
+
+### Improve
+- Codex version detection now falls back to `client_version` from `~/.codex/models_cache.json` and picks the newest usable value across `version.json`, `models_cache.json`, and `codex --version`.
+
+### Fix
+- Fixed cases where the local app could still send an outdated Codex version even after the CLI was upgraded, causing newer models such as `gpt-5.6-sol` to keep returning upgrade-required errors.
+
+--
+
+## v1.3.20
+
+### 新增
+
+### 优化
+- 参考 OpenAI 官方模型目录，界面和代理在未保留旧值时默认优先选中 `gpt-5.6-sol`，与当前 GPT-5.6 系列主模型保持一致。#20
+
+### 修复
+
+### Added
+
+### Improve
+- Following the official OpenAI model catalog, the UI and proxy now prefer `gpt-5.6-sol` when no previous selection is preserved, matching the current flagship model in the GPT-5.6 family.
+
+### Fix
+
+--
+
+## v1.3.19
+
+### 新增
+
+### 优化
+- 当 `~/.codex/version.json` 缺失或未提供版本号时，改为回退读取 `codex --version`，避免已升级的 Codex CLI 仍以旧版本号发起请求。
+
+### 修复
+- 修复部分环境下明明已升级 Codex，却仍因回退到 `0.125.0` 而无法使用 `gpt-5.6-sol` 等新模型的问题。#19
+
+### Added
+
+### Improve
+- When `~/.codex/version.json` is missing or does not expose a version, the app now falls back to `codex --version` so upgraded Codex CLI installs report the real version in upstream requests.
+
+### Fix
+- Fixed an issue where some updated Codex installations still sent the fallback version `0.125.0`, causing newer models such as `gpt-5.6-sol` to be rejected.
+
+--
+
+## v1.3.18
+
+### 新增
+- 内置预设模型列表新增 `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`，模型选择器会直接显示这些模型。#18
+
+### 优化
+
+### 修复
+
+### Added
+- Added `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the built-in preset model list so they appear directly in model selectors.
+
+### Improve
+
+### Fix
+
+--
+
 ## v1.3.17
 
 ### 新增

--- a/Codex_AccountSwitch/app_version.h
+++ b/Codex_AccountSwitch/app_version.h
@@ -1,10 +1,10 @@
 ﻿#pragma execution_character_set("utf-8")
 #pragma once
 
-// v1.3.17
+// v1.3.18
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 3
-#define APP_VERSION_PATCH 17
+#define APP_VERSION_PATCH 18
 #define APP_VERSION_BUILD 0
 
 #define APP_VERSION_STR_HELPER(x) #x

--- a/Codex_AccountSwitch/preset_models.h
+++ b/Codex_AccountSwitch/preset_models.h
@@ -7,6 +7,9 @@
 inline const std::vector<std::wstring> &GetPresetModelIds()
 {
     static const std::vector<std::wstring> kPresetModelIds = {
+        L"gpt-5.6-sol",
+        L"gpt-5.6-terra",
+        L"gpt-5.6-luna",
         L"gpt-5.5",
         L"gpt-5.2",
         L"gpt-5.4",

--- a/Codex_AccountSwitch/webview_host.cpp
+++ b/Codex_AccountSwitch/webview_host.cpp
@@ -55,6 +55,7 @@ namespace
   std::wstring EscapeJsonString(const std::wstring &input);
   std::wstring UnescapeJsonString(const std::wstring &input);
   std::wstring ToLowerCopy(const std::wstring &value);
+  std::wstring TrimWide(const std::wstring &value);
   std::wstring FormatFileTime(const fs::path &path);
   bool ReadUtf8File(const fs::path &file, std::wstring &out);
   bool WriteUtf8File(const fs::path &file, const std::wstring &content);
@@ -67,6 +68,8 @@ namespace
                                      const std::wstring &targetName,
                                      const std::wstring &targetGroup);
   void DebugLogLine(const std::wstring &scope, const std::wstring &message);
+  fs::path GetCodexHomeDir();
+  std::wstring ReadCodexVersionFromCli();
   bool ApplyStealthProxyModeToCodexProfile(const AppConfig &cfg,
                                            std::wstring &error);
   bool RestoreCodexProfileFromStealthBackup(std::wstring &error);
@@ -1628,6 +1631,23 @@ namespace
     return leftLower < rightLower ? -1 : 1;
   }
 
+  std::wstring PickNewerCodexVersion(const std::wstring &currentBest,
+                                     const std::wstring &candidate)
+  {
+    const std::wstring trimmedCandidate = TrimWide(candidate);
+    if (trimmedCandidate.empty())
+    {
+      return currentBest;
+    }
+    if (currentBest.empty())
+    {
+      return trimmedCandidate;
+    }
+    return CompareLooseVersion(trimmedCandidate, currentBest) > 0
+               ? trimmedCandidate
+               : currentBest;
+  }
+
   std::wstring ClampCodexVersionFloor(const std::wstring &value)
   {
     size_t start = 0;
@@ -1651,27 +1671,46 @@ namespace
 
   std::wstring ReadCodexLatestVersion()
   {
-    wchar_t *userProfile = nullptr;
-    size_t required = 0;
-    if (_wdupenv_s(&userProfile, &required, L"USERPROFILE") != 0 ||
-        userProfile == nullptr || *userProfile == L'\0')
+    const fs::path codexHome = GetCodexHomeDir();
+    if (codexHome.empty())
     {
-      free(userProfile);
       return kUsageDefaultCodexVersion;
     }
 
-    const fs::path versionPath =
-        fs::path(userProfile) / L".codex" / L"version.json";
-    free(userProfile);
+    const fs::path versionPath = codexHome / L"version.json";
+    const fs::path modelsCachePath = codexHome / L"models_cache.json";
+    std::wstring bestVersion;
 
     std::wstring json;
-    if (!ReadUtf8File(versionPath, json))
+    if (ReadUtf8File(versionPath, json))
     {
-      return kUsageDefaultCodexVersion;
+      std::wstring latest = ExtractJsonField(json, L"latest_version");
+      if (latest.empty())
+      {
+        latest = ExtractJsonField(json, L"current_version");
+      }
+      if (latest.empty())
+      {
+        latest = ExtractJsonField(json, L"version");
+      }
+      bestVersion = PickNewerCodexVersion(bestVersion, latest);
     }
 
-    const std::wstring latest = ExtractJsonField(json, L"latest_version");
-    return ClampCodexVersionFloor(latest);
+    if (ReadUtf8File(modelsCachePath, json))
+    {
+      const std::wstring clientVersion =
+          ExtractJsonField(json, L"client_version");
+      bestVersion = PickNewerCodexVersion(bestVersion, clientVersion);
+    }
+
+    const std::wstring cliVersion = ReadCodexVersionFromCli();
+    bestVersion = PickNewerCodexVersion(bestVersion, cliVersion);
+
+    if (!bestVersion.empty())
+    {
+      return ClampCodexVersionFloor(bestVersion);
+    }
+    return kUsageDefaultCodexVersion;
   }
 
   std::wstring BuildUsageUserAgent()
@@ -3138,6 +3177,88 @@ namespace
       --end;
     }
     return value.substr(begin, end - begin);
+  }
+
+  std::wstring ReadCodexVersionFromCli()
+  {
+    wchar_t foundPath[32768]{};
+    std::wstring exePath;
+    if (SearchPathW(nullptr, L"codex.exe", nullptr,
+                    static_cast<DWORD>(_countof(foundPath)), foundPath,
+                    nullptr) > 0)
+    {
+      exePath = foundPath;
+    }
+
+    SECURITY_ATTRIBUTES sa{};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = TRUE;
+
+    HANDLE readPipe = nullptr;
+    HANDLE writePipe = nullptr;
+    if (!CreatePipe(&readPipe, &writePipe, &sa, 0))
+    {
+      return L"";
+    }
+    SetHandleInformation(readPipe, HANDLE_FLAG_INHERIT, 0);
+
+    const std::wstring commandLine =
+        exePath.empty() ? L"codex --version" : L"\"" + exePath + L"\" --version";
+    std::vector<wchar_t> buffer(commandLine.begin(), commandLine.end());
+    buffer.push_back(L'\0');
+
+    STARTUPINFOW si{};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = writePipe;
+    si.hStdError = writePipe;
+
+    PROCESS_INFORMATION pi{};
+    const BOOL ok = CreateProcessW(
+        exePath.empty() ? nullptr : exePath.c_str(), buffer.data(), nullptr,
+        nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi);
+    CloseHandle(writePipe);
+
+    if (!ok)
+    {
+      CloseHandle(readPipe);
+      return L"";
+    }
+
+    std::string output;
+    char chunk[256]{};
+    DWORD read = 0;
+    while (ReadFile(readPipe, chunk, sizeof(chunk), &read, nullptr) && read > 0)
+    {
+      output.append(chunk, chunk + read);
+    }
+    CloseHandle(readPipe);
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exitCode = 1;
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    if (exitCode != 0)
+    {
+      return L"";
+    }
+
+    const std::wstring text = TrimWide(FromUtf8(output));
+    if (text.empty())
+    {
+      return L"";
+    }
+
+    const std::wregex versionRe(
+        LR"((\d+\.\d+\.\d+(?:[-+][0-9A-Za-z\.-]+)?))");
+    std::wsmatch match;
+    if (!std::regex_search(text, match, versionRe))
+    {
+      return L"";
+    }
+    return ClampCodexVersionFloor(match[1].str());
   }
 
   bool IsTopLevelManagedTomlKey(const std::wstring &line)
@@ -10533,7 +10654,7 @@ namespace
   {
     for (const auto &model : models)
     {
-      if (EqualsIgnoreCase(model, L"gpt-5.5"))
+      if (EqualsIgnoreCase(model, L"gpt-5.6-sol"))
       {
         return model;
       }

--- a/webui/js/app.js
+++ b/webui/js/app.js
@@ -3,6 +3,9 @@
 
   const IDE_LIST = ["Code.exe", "Trae.exe", "Kiro.exe", "Antigravity.exe"];
   const FALLBACK_API_MODELS = [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.2",
     "gpt-5.4",
@@ -2811,7 +2814,7 @@
       if (prevValue && models.includes(prevValue)) {
         dom.apiModelSelect.value = prevValue;
       } else if (models.length > 0) {
-        const preferred = models.find((x) => x === "gpt-5.5") || models[0];
+        const preferred = models.find((x) => x === "gpt-5.6-sol") || models[0];
         dom.apiModelSelect.value = preferred;
       }
     }


### PR DESCRIPTION
…回退问题